### PR TITLE
Make nested resources work with CanCan

### DIFF
--- a/lib/link_to_action/helpers.rb
+++ b/lib/link_to_action/helpers.rb
@@ -81,8 +81,9 @@ module LinkToAction::Helpers
     end
   end
 
-  def link_to_action_cancan?(*args)
-    args[0] == :back || ( LinkToAction.use_cancan ? can?(*args) : true )
+  def link_to_action_cancan?(action, object)
+    object = (object.is_a?(Array) ? Hash[*object] : object)
+    action == :back || (LinkToAction.use_cancan ? can?(action, object) : true)
   end
 end
 

--- a/lib/link_to_action/helpers.rb
+++ b/lib/link_to_action/helpers.rb
@@ -82,7 +82,7 @@ module LinkToAction::Helpers
   end
 
   def link_to_action_cancan?(action, object)
-    object = (object.is_a?(Array) ? Hash[*object] : object)
+    object = (object.is_a?(Array) ? Hash[*(object.last(2))] : object)
     action == :back || (LinkToAction.use_cancan ? can?(action, object) : true)
   end
 end


### PR DESCRIPTION
CanCan does not work with nested resources because you are passing resources to CanCan as an array and not as a hash. This pull request should fix the issue.
